### PR TITLE
fix: improve config loading and prevent command blinking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+tc-debug.log


### PR DESCRIPTION
The plugin had two main issues:
1. Config file parsing would stop after first entry
2. Tab color would reset/blink on every command

Changes:
- Fix config parsing to load all entries correctly
- Make arrays properly global (-g flag) to persist between function calls
- Add debug logging capability (disabled by default, enable with TC_DEBUG=1)
- Only reset colors on directory changes, not commands
- Improve pattern matching reliability

The plugin now correctly:
- Loads all color configurations
- Maintains array state between function calls
- Changes colors only when entering/leaving configured directories
- Maintains color stability during command execution